### PR TITLE
Cleanup unnecessary dependencies with some updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
 *~
-/pkg/
-/tmp/
-*.gemspec
 .gradle/
-classpath/
 build/
 .idea
-embulk-input-ftp/out/
-embulk-util-ftp/out/

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 group = "org.embulk"
@@ -33,12 +32,11 @@ java {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.19"
-    compileOnly "org.embulk:embulk-spi:0.10.19"
+    compileOnly "org.embulk:embulk-api:0.10.31"
 
-    compile("org.embulk:embulk-util-config:0.1.4") {
+    implementation("org.embulk:embulk-util-config:0.3.1") {
         // They conflict with embulk-core. They are once excluded here,
-        // and added explicitly with versions exactly the same with embulk-core:0.10.19.
+        // and added explicitly with versions exactly the same with embulk-core:0.10.31.
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
@@ -47,28 +45,35 @@ dependencies {
     }
 
     // They are once excluded from transitive dependencies of other dependencies,
-    // and added explicitly with versions exactly the same with embulk-core:0.10.19.
-    compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
-    compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
-    compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
-    compile "javax.validation:validation-api:1.1.0.Final"
+    // and added explicitly with versions exactly the same with embulk-core:0.10.31.
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
+    implementation "javax.validation:validation-api:1.1.0.Final"
 
-    compile "org.bouncycastle:bcpkix-jdk15on:1.52"
+    implementation "org.bouncycastle:bcpkix-jdk15on:1.52"
 
-    testCompile "junit:junit:4.13"
-    testCompile "org.embulk:embulk-core:0.10.19"
-    testCompile "org.embulk:embulk-core:0.10.19:tests"
-    testCompile "org.embulk:embulk-deps:0.10.19"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "com.google.guava:guava:18.0"
+    testImplementation "org.embulk:embulk-api:0.10.31"
 }
 
 publishing {
     publications {
-        maven(MavenPublication) {  // Publish it with "publishMavenPublicationToMavenCentralRepository".
+        maven(MavenPublication) {
+            groupId = project.group
+            artifactId = project.name
+
             from components.java  // Must be "components.java". The dependency modification works only for it.
+            // javadocJar and sourcesJar are added by java.withJavadocJar() and java.withSourcesJar() above.
+            // See: https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html
 
             pom {  // https://central.sonatype.org/pages/requirements.html
                 packaging "jar"
+
+                name = project.name
+                description = project.description
                 url = "https://www.embulk.org/"
 
                 licenses {
@@ -84,12 +89,20 @@ publishing {
                         name = "Sadayuki Furuhashi"
                         email = "frsyuki@gmail.com"
                     }
+                    developer {
+                        name = "Satoshi Akama"
+                        email = "satoshiakama@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
                 }
 
                 scm {
-                    connection = "scm:git:git://github.com/embulk/embulk-input-ftp.git"
-                    developerConnection = "scm:git:git@github.com:embulk/embulk-input-ftp.git"
-                    url = "https://github.com/embulk/embulk-input-ftp"
+                    connection = "scm:git:git://github.com/embulk/embulk-util-ssl.git"
+                    developerConnection = "scm:git:git@github.com:embulk/embulk-util-ssl.git"
+                    url = "https://github.com/embulk/embulk-util-ssl"
                 }
             }
         }

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -8,8 +8,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.bouncycastle:bcpkix-jdk15on:1.52
 org.bouncycastle:bcprov-jdk15on:1.52
-org.embulk:embulk-api:0.10.19
-org.embulk:embulk-spi:0.10.19
-org.embulk:embulk-util-config:0.1.4
+org.embulk:embulk-api:0.10.31
+org.embulk:embulk-util-config:0.3.1
 org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.slf4j:slf4j-api:1.7.30

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -8,4 +8,4 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.bouncycastle:bcpkix-jdk15on:1.52
 org.bouncycastle:bcprov-jdk15on:1.52
-org.embulk:embulk-util-config:0.1.4
+org.embulk:embulk-util-config:0.3.1

--- a/src/test/java/org/embulk/util/ssl/TestSSLPlugins.java
+++ b/src/test/java/org/embulk/util/ssl/TestSSLPlugins.java
@@ -1,10 +1,8 @@
 package org.embulk.util.ssl;
 
 import com.google.common.io.Resources;
-import org.embulk.EmbulkTestRuntime;
 import org.embulk.util.ssl.SSLPlugins.SSLPluginConfig;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -24,9 +22,6 @@ public class TestSSLPlugins
 {
     private static String FTP_TEST_SSL_TRUSTED_CA_CERT_FILE;
     private static String FTP_TEST_SSL_TRUSTED_CA_CERT_DATA;
-
-    @Rule
-    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     @Before
     public void createResources() throws Exception

--- a/src/test/java/org/embulk/util/ssl/TestTrustManagers.java
+++ b/src/test/java/org/embulk/util/ssl/TestTrustManagers.java
@@ -1,9 +1,7 @@
 package org.embulk.util.ssl;
 
 import com.google.common.io.Resources;
-import org.embulk.EmbulkTestRuntime;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.StringReader;
@@ -13,9 +11,6 @@ import java.util.List;
 public class TestTrustManagers
 {
     private static String FTP_TEST_SSL_TRUSTED_CA_CERT_DATA;
-
-    @Rule
-    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     @Before
     public void createResources()


### PR DESCRIPTION
After #1, it cleans up unnecessary dependencies, and updates `embulk-util-config` to the latest `0.3.1`.