### PR TITLE
support configure crypto policy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.1-SNAPSHOT"
 description = "SSL utility classes for Embulk plugins."
 
 sourceCompatibility = 1.8

--- a/src/test/java/org/embulk/util/ssl/TestSSLPlugins.java
+++ b/src/test/java/org/embulk/util/ssl/TestSSLPlugins.java
@@ -151,6 +151,12 @@ public class TestSSLPlugins
         {
             this.caCertData = Optional.of(certData);
         }
+
+        @Override
+        public Optional<SSLPlugins.CryptoPolicy> getCryptoPolicy()
+        {
+            return Optional.empty();
+        }
     }
 
     private String getFileContents(String path) throws Exception


### PR DESCRIPTION
Some country has different policy for Java Cryptography Extension (JCE) strength. We want to add a new configuration to help users able select an appropriate policy base on their country's restrictions.